### PR TITLE
Support for v2 API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 backports.ssl-match-hostname==3.4.0.2
 google-api-python-client==1.4.2
-helpscout==0.0.1
+python-helpscout-v2==1.0.0
 httplib2==0.9.1
 lxml==4.1.1
 oauth2client==1.5.1


### PR DESCRIPTION
The helpscout library we were using before doesn't have support for the v2 API, so this implements support for python-helpscout-v2.
Not much of a change, but does get us reasonable paging.